### PR TITLE
Hotfix/image size error

### DIFF
--- a/Controller/Admin/CsvImportController.php
+++ b/Controller/Admin/CsvImportController.php
@@ -370,6 +370,27 @@ class CsvImportController extends AbstractCsvImportController
                         // call image search
                         foreach ($this->pImages as $pImage) {
                             $pFilePath = $this->eccubeConfig['eccube_save_image_dir'] . '/' . $pImage;
+
+                            $maxWidth = 1024;
+                            $maxHeight = 1024;
+                            $imagick = new \Imagick();
+                            $imagick->readImage($pFilePath);
+                            $orgWidth = $imagick->getImageWidth();
+                            $orgHeight = $imagick->getImageHeight();
+                            if ($orgWidth > $maxWidth || $orgHeight > $maxHeight) {
+                                $ratio = $orgWidth / $orgHeight;
+                                if ($maxWidth / $maxHeight > $ratio) {
+                                    $maxWidth = $maxHeight * $ratio;
+                                } else {
+                                    $maxHeight = $maxWidth / $ratio;
+                                }
+                                $imagick->scaleImage($maxWidth, $maxHeight);
+                                $imagick->setCompressionQuality(80);
+                                $imagick->writeImage($pFilePath);
+                            }
+                            $imagick->clear();
+                            $imagick->destroy();
+
                             AlibabaCloud::ImageSearch()
                                 ->V20190325()
                                 ->AddImage()

--- a/Controller/Admin/ProductAjaxController.php
+++ b/Controller/Admin/ProductAjaxController.php
@@ -82,6 +82,27 @@ class ProductAjaxController extends AbstractController
         foreach ($list as $item) {
             $filePath = $this->eccubeConfig['eccube_save_image_dir'] . '/' . $item->getFileName();
             $id = $item->getProduct()->getId();
+
+            $maxWidth = 1024;
+            $maxHeight = 1024;
+            $imagick = new \Imagick();
+            $imagick->readImage($filePath);
+            $orgWidth = $imagick->getImageWidth();
+            $orgHeight = $imagick->getImageHeight();
+            if ($orgWidth > $maxWidth || $orgHeight > $maxHeight) {
+                $ratio = $orgWidth / $orgHeight;
+                if ($maxWidth / $maxHeight > $ratio) {
+                    $maxWidth = $maxHeight * $ratio;
+                } else {
+                    $maxHeight = $maxWidth / $ratio;
+                }
+                $imagick->scaleImage($maxWidth, $maxHeight);
+                $imagick->setCompressionQuality(80);
+                $imagick->writeImage($filePath);
+            }
+            $imagick->clear();
+            $imagick->destroy();
+
             $result = AlibabaCloud::ImageSearch()
                 ->V20190325()
                 ->AddImage()

--- a/Controller/Admin/ProductController.php
+++ b/Controller/Admin/ProductController.php
@@ -473,6 +473,27 @@ class ProductController extends AbstractController
                     if ($this->Config) {
                         // add image search
                         $filePath = $this->eccubeConfig['eccube_save_image_dir'] . '/' . $add_image;
+
+                        $maxWidth = 1024;
+                        $maxHeight = 1024;
+                        $imagick = new \Imagick();
+                        $imagick->readImage($filePath);
+                        $orgWidth = $imagick->getImageWidth();
+                        $orgHeight = $imagick->getImageHeight();
+                        if ($orgWidth > $maxWidth || $orgHeight > $maxHeight) {
+                            $ratio = $orgWidth / $orgHeight;
+                            if ($maxWidth / $maxHeight > $ratio) {
+                                $maxWidth = $maxHeight * $ratio;
+                            } else {
+                                $maxHeight = $maxWidth / $ratio;
+                            }
+                            $imagick->scaleImage($maxWidth, $maxHeight);
+                            $imagick->setCompressionQuality(80);
+                            $imagick->writeImage($filePath);
+                        }
+                        $imagick->clear();
+                        $imagick->destroy();
+
                         AlibabaCloud::ImageSearch()
                             ->V20190325()
                             ->AddImage()
@@ -852,6 +873,7 @@ class ProductController extends AbstractController
                 if ($this->Config && $copyFilenameList) {
                     foreach ($copyFilenameList as $copyFilenameItem) {
                         $filePath = $this->eccubeConfig['eccube_save_image_dir'] . '/' . $copyFilenameItem;
+                        //登録済みの商品をコピする場合、画像圧縮不要
                         AlibabaCloud::ImageSearch()
                             ->V20190325()
                             ->AddImage()

--- a/Controller/Admin/ProductController.php
+++ b/Controller/Admin/ProductController.php
@@ -494,16 +494,21 @@ class ProductController extends AbstractController
                         $imagick->clear();
                         $imagick->destroy();
 
-                        AlibabaCloud::ImageSearch()
-                            ->V20190325()
-                            ->AddImage()
-                            ->contentType('application/x-www-form-urlencoded; charset=UTF-8')
-                            ->withInstanceName($this->Config->getInstanceName())
-                            ->withProductId($Product->getId())
-                            ->withPicName($add_image)
-                            ->withPicContent(base64_encode(file_get_contents($filePath)))
-                            ->debug(false)
-                            ->request();
+                        try {
+                          AlibabaCloud::ImageSearch()
+                              ->V20190325()
+                              ->AddImage()
+                              ->contentType('application/x-www-form-urlencoded; charset=UTF-8')
+                              ->withInstanceName($this->Config->getInstanceName())
+                              ->withProductId($Product->getId())
+                              ->withPicName($add_image)
+                              ->withPicContent(base64_encode(file_get_contents($filePath)))
+                              ->debug(false)
+                              ->request();
+                        } catch (\Exception $e) {
+                            $this->addError('画像検索の登録が失敗しましたが、商品登録は継続します。', 'admin');
+                            log_warning('画像検索の登録が失敗しましたが、商品登録は継続します。');
+                        }
                         sleep(1);
                     }
                 }

--- a/Controller/ImageSearchController.php
+++ b/Controller/ImageSearchController.php
@@ -97,6 +97,27 @@ class ImageSearchController extends AbstractController
                 'message' => 'Please upload pictures in jpg or png format',
             ]);
         }
+
+        $maxWidth = 1024;
+        $maxHeight = 1024;
+        $imagick = new \Imagick();
+        $imagick->readImage($_FILES['upload_image']['tmp_name']);
+        $orgWidth = $imagick->getImageWidth();
+        $orgHeight = $imagick->getImageHeight();
+        if ($orgWidth > $maxWidth || $orgHeight > $maxHeight) {
+            $ratio = $orgWidth / $orgHeight;
+            if ($maxWidth / $maxHeight > $ratio) {
+                $maxWidth = $maxHeight * $ratio;
+            } else {
+                $maxHeight = $maxWidth / $ratio;
+            }
+            $imagick->scaleImage($maxWidth, $maxHeight);
+            $imagick->setCompressionQuality(80);
+            $imagick->writeImage($_FILES['upload_image']['tmp_name']);
+        }
+        $imagick->clear();
+        $imagick->destroy();
+
         if ($_FILES['upload_image']['size'] > 1048576) {
             return $this->json(['status' => false, 'message' => 'Please upload an image smaller than 1MB']);
         }

--- a/Resource/template/default/Block/search_product.twig
+++ b/Resource/template/default/Block/search_product.twig
@@ -62,7 +62,6 @@ jQuery(document).ready(function () {
     }
 
     var _extendArray = ['png','jpg']
-    var _fileSizeLimit = 1048576
 
     jQuery('.ec-headerNaviRole .pImgSearch').click(function () {
         jQuery(this).siblings("input[name='imageSearch']").trigger('click')
@@ -79,10 +78,6 @@ jQuery(document).ready(function () {
         var _fileSize = _this[0].files[0].size // 1048576
         if (_extendArray.indexOf(_extend) == -1) {
             alert('Please upload pictures in jpg or png format')
-            return false
-        }
-        if (_fileSize > _fileSizeLimit) {
-            alert('Please upload an image smaller than 1MB')
             return false
         }
 
@@ -127,7 +122,6 @@ jQuery(document).ready(function () {
     }
 
     var _extendArray = ['png','jpg']
-    var _fileSizeLimit = 1048576
 
     jQuery('.ec-drawerRole .pImgSearch').click(function () {
         jQuery(this).siblings("input[name='imageSearch']").trigger('click')
@@ -144,10 +138,6 @@ jQuery(document).ready(function () {
         var _fileSize = _this[0].files[0].size // 1048576
         if (_extendArray.indexOf(_extend) == -1) {
             alert('Please upload pictures in jpg or png format')
-            return false
-        }
-        if (_fileSize > _fileSizeLimit) {
-            alert('Please upload an image smaller than 1MB')
             return false
         }
         jQuery('.ec-drawerRoleClose').trigger('click')


### PR DESCRIPTION
・画像のサイズは1024ピクセルを超える場合、1024ピクセル以内に収まるようにリサイズします。
・Qualityを80にします。
・それでも2Mを超える場合はエラーメッセージを管理画面に表示し、商品登録自体は継続させます。